### PR TITLE
Add Selenium TestNG framework for SauceDemo login automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,40 @@
-# Java-Selenium-TestNG
+# Java Selenium TestNG Framework
+
+This project contains a basic Selenium + TestNG automation framework built using the Page Object Model (POM) pattern. The first sample test covers a successful login to [Sauce Demo](https://www.saucedemo.com/).
+
+## Tech stack
+- Java 11
+- Maven
+- Selenium 4.20.0
+- TestNG 7.9.0
+- WebDriverManager 5.8.0
+
+## Project structure
+```
+src
+├── main
+│   └── java
+│       └── com
+│           └── saucedemo
+│               └── pages
+│                   ├── BasePage.java
+│                   ├── InventoryPage.java
+│                   └── LoginPage.java
+└── test
+    └── java
+        └── com
+            └── saucedemo
+                ├── base
+                │   └── BaseTest.java
+                └── tests
+                    └── LoginTest.java
+```
+
+## Running the tests
+1. Ensure you have Java 11+ and Maven installed.
+2. Execute the tests with:
+   ```bash
+   mvn test
+   ```
+
+> **Note:** The tests run Chrome in headless mode. Google Chrome must be installed on the machine executing the tests.

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,49 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.saucedemo</groupId>
+    <artifactId>selenium-testng-framework</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <properties>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.seleniumhq.selenium</groupId>
+            <artifactId>selenium-java</artifactId>
+            <version>4.20.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <version>7.9.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.github.bonigarcia</groupId>
+            <artifactId>webdrivermanager</artifactId>
+            <version>5.8.0</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.2.5</version>
+                <configuration>
+                    <includes>
+                        <include>**/*Test.java</include>
+                    </includes>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/main/java/com/saucedemo/pages/BasePage.java
+++ b/src/main/java/com/saucedemo/pages/BasePage.java
@@ -1,0 +1,20 @@
+package com.saucedemo.pages;
+
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.support.ui.WebDriverWait;
+
+import java.time.Duration;
+
+public abstract class BasePage {
+    protected final WebDriver driver;
+    protected final WebDriverWait wait;
+
+    protected BasePage(WebDriver driver) {
+        this.driver = driver;
+        this.wait = new WebDriverWait(driver, Duration.ofSeconds(10));
+    }
+
+    public String getPageTitle() {
+        return driver.getTitle();
+    }
+}

--- a/src/main/java/com/saucedemo/pages/InventoryPage.java
+++ b/src/main/java/com/saucedemo/pages/InventoryPage.java
@@ -1,0 +1,18 @@
+package com.saucedemo.pages;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+
+public class InventoryPage extends BasePage {
+
+    private final By productsTitle = By.cssSelector(".title");
+
+    public InventoryPage(WebDriver driver) {
+        super(driver);
+    }
+
+    public boolean isLoaded() {
+        return wait.until(ExpectedConditions.textToBePresentInElementLocated(productsTitle, "Products"));
+    }
+}

--- a/src/main/java/com/saucedemo/pages/LoginPage.java
+++ b/src/main/java/com/saucedemo/pages/LoginPage.java
@@ -1,0 +1,48 @@
+package com.saucedemo.pages;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+
+public class LoginPage extends BasePage {
+
+    private static final String PAGE_URL = "https://www.saucedemo.com/";
+
+    private final By usernameField = By.id("user-name");
+    private final By passwordField = By.id("password");
+    private final By loginButton = By.id("login-button");
+
+    public LoginPage(WebDriver driver) {
+        super(driver);
+    }
+
+    public LoginPage open() {
+        driver.get(PAGE_URL);
+        wait.until(ExpectedConditions.visibilityOfElementLocated(usernameField));
+        return this;
+    }
+
+    public void enterUsername(String username) {
+        WebElement usernameInput = wait.until(ExpectedConditions.elementToBeClickable(usernameField));
+        usernameInput.clear();
+        usernameInput.sendKeys(username);
+    }
+
+    public void enterPassword(String password) {
+        WebElement passwordInput = wait.until(ExpectedConditions.elementToBeClickable(passwordField));
+        passwordInput.clear();
+        passwordInput.sendKeys(password);
+    }
+
+    public InventoryPage submitLogin() {
+        wait.until(ExpectedConditions.elementToBeClickable(loginButton)).click();
+        return new InventoryPage(driver);
+    }
+
+    public InventoryPage loginAs(String username, String password) {
+        enterUsername(username);
+        enterPassword(password);
+        return submitLogin();
+    }
+}

--- a/src/test/java/com/saucedemo/base/BaseTest.java
+++ b/src/test/java/com/saucedemo/base/BaseTest.java
@@ -1,0 +1,31 @@
+package com.saucedemo.base;
+
+import io.github.bonigarcia.wdm.WebDriverManager;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.chrome.ChromeDriver;
+import org.openqa.selenium.chrome.ChromeOptions;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+
+public abstract class BaseTest {
+
+    protected WebDriver driver;
+
+    @BeforeMethod(alwaysRun = true)
+    public void setUp() {
+        WebDriverManager.chromedriver().setup();
+        ChromeOptions options = new ChromeOptions();
+        options.addArguments("--headless=new");
+        options.addArguments("--disable-gpu");
+        options.addArguments("--window-size=1920,1080");
+        driver = new ChromeDriver(options);
+        driver.manage().deleteAllCookies();
+    }
+
+    @AfterMethod(alwaysRun = true)
+    public void tearDown() {
+        if (driver != null) {
+            driver.quit();
+        }
+    }
+}

--- a/src/test/java/com/saucedemo/tests/LoginTest.java
+++ b/src/test/java/com/saucedemo/tests/LoginTest.java
@@ -1,0 +1,17 @@
+package com.saucedemo.tests;
+
+import com.saucedemo.base.BaseTest;
+import com.saucedemo.pages.InventoryPage;
+import com.saucedemo.pages.LoginPage;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class LoginTest extends BaseTest {
+
+    @Test(description = "Verify that a standard user can log in successfully")
+    public void testSuccessfulLogin() {
+        LoginPage loginPage = new LoginPage(driver).open();
+        InventoryPage inventoryPage = loginPage.loginAs("standard_user", "secret_sauce");
+        Assert.assertTrue(inventoryPage.isLoaded(), "Inventory page should be displayed after login");
+    }
+}


### PR DESCRIPTION
## Summary
- add a Maven configuration with Selenium 4.20.0, TestNG, and WebDriverManager
- implement Sauce Demo page objects using the Page Object Model
- create a headless Chrome BaseTest, login test case, and update the project README

## Testing
- mvn -q -DskipTests package *(fails: Maven Central returned 403 for maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68fbc93524ac832fba3f20cf1e91d780